### PR TITLE
VEOSS-588 | Added "Paid" and "No payment due" to past-returns page

### DIFF
--- a/app/models/PaymentState.scala
+++ b/app/models/PaymentState.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import models.Quarter.values
+
+import java.time.Month
+
+sealed trait PaymentState {
+}
+
+object PaymentState extends Enumerable.Implicits {
+
+  case object NoneDue extends WithName("returnSubmitted.noneDue") with PaymentState
+  case object PaymentDue extends WithName("returnSubmitted.payNow") with PaymentState
+  case object Paid extends WithName("returnSubmitted.paid") with PaymentState
+
+  val values: Seq[PaymentState] = Seq(NoneDue, PaymentDue, Paid)
+
+  implicit val enumerable: Enumerable[PaymentState] =
+    Enumerable(values.map(v => v.toString -> v): _*)
+
+
+
+}
+

--- a/app/models/PaymentState.scala
+++ b/app/models/PaymentState.scala
@@ -16,12 +16,7 @@
 
 package models
 
-import models.Quarter.values
-
-import java.time.Month
-
-sealed trait PaymentState {
-}
+sealed trait PaymentState
 
 object PaymentState extends Enumerable.Implicits {
 
@@ -33,8 +28,5 @@ object PaymentState extends Enumerable.Implicits {
 
   implicit val enumerable: Enumerable[PaymentState] =
     Enumerable(values.map(v => v.toString -> v): _*)
-
-
-
 }
 

--- a/app/models/financialdata/VatReturnWithFinancialData.scala
+++ b/app/models/financialdata/VatReturnWithFinancialData.scala
@@ -16,6 +16,8 @@
 
 package models.financialdata
 
+import models.PaymentState
+import models.PaymentState.{NoneDue, Paid, PaymentDue}
 import models.domain.VatReturn
 import play.api.libs.json.{Format, Json}
 
@@ -25,6 +27,16 @@ case class VatReturnWithFinancialData(vatReturn: VatReturn, charge: Option[Charg
     (charge.isEmpty || charge.exists(c => c.outstandingAmount > 0))
 
   val showUpdating: Boolean = charge.isEmpty && vatOwed.getOrElse(0L) > 0L
+
+  def paymentState: PaymentState = {
+    if(showPayNow) {
+      PaymentDue
+    } else if(charge.exists(c => c.originalAmount > 0 && c.outstandingAmount == 0)) {
+      Paid
+    } else {
+      NoneDue
+    }
+  }
 }
 
 object VatReturnWithFinancialData {

--- a/app/views/SubmittedReturnsHistoryView.scala.html
+++ b/app/views/SubmittedReturnsHistoryView.scala.html
@@ -16,6 +16,7 @@
 
 @import utils.CurrencyFormatter.currencyFormat
 @import models.financialdata.VatReturnWithFinancialData
+@import models.PaymentState._
 
 @this(
         layout: templates.Layout
@@ -68,7 +69,7 @@
                             <tr class="govuk-table__row">
                                 <th scope="col" class="govuk-table__header">@messages("submittedReturnsHistory.returnPeriod")</th>
                                 <th scope="col" class="govuk-table__header">@messages("submittedReturnsHistory.amountLeftToPay")</th>
-                                <th scope="col" class="govuk-table__header"></th>
+                                <th scope="col" class="govuk-table__header">@messages("submittedReturnsHistory.payment")</th>
                             </tr>
                         </thead>
                         <tbody class="govuk-table__body">
@@ -85,8 +86,10 @@
                                 }
                                 </td>
                                 <td class="govuk-table__cell">
-                                @if(vatReturnWithFinancialData.showPayNow) {
-                                    <a class="govuk-link" href="@routes.PaymentController.makePayment(vatReturnWithFinancialData.vatReturn.period, vatReturnWithFinancialData.vatOwed.get)">@messages("returnSubmitted.payNow")</a>
+                                @if(vatReturnWithFinancialData.paymentState == PaymentDue) {
+                                    <a class="govuk-link" href="@routes.PaymentController.makePayment(vatReturnWithFinancialData.vatReturn.period, vatReturnWithFinancialData.vatOwed.get)">@messages(vatReturnWithFinancialData.paymentState.toString)</a>
+                                } else {
+                                    @messages(vatReturnWithFinancialData.paymentState.toString)
                                 }
                                 </td>
                             </tr>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -234,6 +234,8 @@ returnSubmitted.payVatOwed = Pay VAT owed
 returnSubmitted.payVatOwed.p1 = For {0}, you owe
 returnSubmitted.payVatOwed.p2 = You can pay by corporate card or bank transfer.
 returnSubmitted.payNow = Pay now
+returnSubmitted.noneDue = No payment due
+returnSubmitted.paid = Paid
 returnSubmitted.payBy.p1 = You need to pay by {0}.
 returnSubmitted.payBy.p2 = EU countries can charge you interest or penalties for late payments.
 returnSubmitted.overduePayBy.p1 = Payment for this return was due by {0}.
@@ -247,6 +249,7 @@ submittedReturnsHistory.sub-heading = View and pay your previous returns
 submittedReturnsHistory.no-returns = You have not submitted any returns for this year.
 submittedReturnsHistory.returnPeriod = Return period
 submittedReturnsHistory.amountLeftToPay = Amount left to pay
+submittedReturnsHistory.payment = Payment
 submittedReturnsHistory.updating = Updating
 
 notificationBanner.title = Important

--- a/test/models/financialdata/VatReturnWithFinancialDataSpec.scala
+++ b/test/models/financialdata/VatReturnWithFinancialDataSpec.scala
@@ -18,6 +18,7 @@ package models.financialdata
 
 import base.SpecBase
 import generators.Generators
+import models.PaymentState.{NoneDue, Paid, PaymentDue}
 import org.scalatest.EitherValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -32,31 +33,48 @@ class VatReturnWithFinancialDataSpec extends AnyFreeSpec
   "showPayNow" - {
 
     "is true when" - {
+
       "the return is not nil and there is an outstanding charge" in {
         val returnWithData = VatReturnWithFinancialData(completeVatReturn, Some(outstandingCharge), Some(vatAmount))
         returnWithData.showPayNow mustBe true
+        returnWithData.paymentState mustBe PaymentDue
       }
 
       "the return is not nil and there is no charge" in {
         val returnWithData = VatReturnWithFinancialData(completeVatReturn, None, Some(vatAmount))
         returnWithData.showPayNow mustBe true
+        returnWithData.paymentState mustBe PaymentDue
       }
     }
 
     "is false when" - {
+
       "the return is nil and there is no charge" in {
         val returnWithData = VatReturnWithFinancialData(completeVatReturn, None, Some(0L))
         returnWithData.showPayNow mustBe false
+        returnWithData.paymentState mustBe NoneDue
       }
 
-      "the return is not nil and there is zero outstanding charge" in {
-        val returnWithData = VatReturnWithFinancialData(completeVatReturn, Some(payedCharge), Some(0L))
-        returnWithData.showPayNow mustBe false
+      "the return is not nil and there is zero outstanding charge" - {
+
+        "and there is an initial charge" in {
+          val returnWithData = VatReturnWithFinancialData(completeVatReturn, Some(payedCharge), Some(0L))
+          returnWithData.showPayNow mustBe false
+          returnWithData.paymentState mustBe Paid
+        }
+
+        "and there is no initial charge" in {
+          val payedCharge = Charge(completeVatReturn.period, BigDecimal(0), BigDecimal(0), BigDecimal(0))
+          val returnWithData = VatReturnWithFinancialData(completeVatReturn, Some(payedCharge), Some(0L))
+          returnWithData.showPayNow mustBe false
+          returnWithData.paymentState mustBe NoneDue
+        }
       }
 
       "the vat owed is none and there is no outstanding charge" in {
         val returnWithData = VatReturnWithFinancialData(completeVatReturn, None, None)
         returnWithData.showPayNow mustBe false
+        returnWithData.paymentState mustBe NoneDue
       }
     }
   }

--- a/test/models/financialdata/VatReturnWithFinancialDataSpec.scala
+++ b/test/models/financialdata/VatReturnWithFinancialDataSpec.scala
@@ -64,8 +64,8 @@ class VatReturnWithFinancialDataSpec extends AnyFreeSpec
         }
 
         "and there is no initial charge" in {
-          val payedCharge = Charge(completeVatReturn.period, BigDecimal(0), BigDecimal(0), BigDecimal(0))
-          val returnWithData = VatReturnWithFinancialData(completeVatReturn, Some(payedCharge), Some(0L))
+          val noCharge = Charge(emptyVatReturn.period, BigDecimal(0), BigDecimal(0), BigDecimal(0))
+          val returnWithData = VatReturnWithFinancialData(emptyVatReturn, Some(noCharge), Some(0L))
           returnWithData.showPayNow mustBe false
           returnWithData.paymentState mustBe NoneDue
         }


### PR DESCRIPTION
"Pay now" as it is currently.
"Paid" when there is no outstanding payment - i.e. there is a non-zero initial amount, but no outstanding amount
No payment due for nil returns - i.e. there was no VAT due on the return
