### PR TITLE
VEOSS-896| initial work to alter the error page for when core is down

### DIFF
--- a/app/views/ReceivedErrorFromCoreView.scala.html
+++ b/app/views/ReceivedErrorFromCoreView.scala.html
@@ -34,6 +34,9 @@
 
     <p class="govuk-body">@messages("errorFromCore.savedAnswers")</p>
 
+    <p class="govuk-body">@Html(messages("errorFromCore.knownIssues"))</p>
+
+    <p class="govuk-body">@messages("errorFromCore.contactUs")</p>
 
     <p class="govuk-body">
         <a href="@routes.YourAccountController.onPageLoad()" id="backToYourAccount">@messages("errorFromCore.your.account")</a>

--- a/app/views/ReceivedErrorFromCoreView.scala.html
+++ b/app/views/ReceivedErrorFromCoreView.scala.html
@@ -36,9 +36,11 @@
 
     <p class="govuk-body">@Html(messages("errorFromCore.knownIssues"))</p>
 
-    <p class="govuk-body">@messages("errorFromCore.contactUs")</p>
+    <p class="govuk-body">@Html(messages("errorFromCore.contactUs"))</p>
 
-    <p class="govuk-body">
-        <a href="@routes.YourAccountController.onPageLoad()" id="backToYourAccount">@messages("errorFromCore.your.account")</a>
-    </p>
+@govukButton(
+ButtonViewModel(messages("errorFromCore.your.account"))
+.asLink(routes.YourAccountController.onPageLoad().url)
+.withAttribute(("id", "backToYourAccount"))
+)
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -489,4 +489,6 @@ notRegisteredCore.your.account = Back to your account
 errorFromCore.title = There is a problem with the service
 errorFromCore.heading = Your return is not submitted
 errorFromCore.savedAnswers = We have saved your answers and you can submit it from your account later.
+errorFromCore.knownIssues = Check our <a class="govuk-link" href="https://www.gov.uk/government/publications/one-stop-shop-union-scheme-service-availability-and-issues">service page</a> for any known system issues.
+errorFromCore.contactUs = If the problem continues, you can contact us.
 errorFromCore.your.account = Back to your account

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -490,5 +490,5 @@ errorFromCore.title = There is a problem with the service
 errorFromCore.heading = Your return is not submitted
 errorFromCore.savedAnswers = We have saved your answers and you can submit it from your account later.
 errorFromCore.knownIssues = Check our <a class="govuk-link" href="https://www.gov.uk/government/publications/one-stop-shop-union-scheme-service-availability-and-issues">service page</a> for any known system issues.
-errorFromCore.contactUs = If the problem continues, you can contact us.
+errorFromCore.contactUs = If the problem continues, you can <a class="govuk-link" href="mailto:vat2015.contact@hmrc.gov.uk">contact us</a>.
 errorFromCore.your.account = Back to your account


### PR DESCRIPTION
We need confirmation where the "contact us" link should redirect